### PR TITLE
Removed the 'init' method from the tables, added instead a 'setInitia…

### DIFF
--- a/core-lib/src/main/java/com/workflowconversion/portlet/core/resource/ResourceProvider.java
+++ b/core-lib/src/main/java/com/workflowconversion/portlet/core/resource/ResourceProvider.java
@@ -20,9 +20,9 @@ public interface ResourceProvider extends Serializable {
 	public boolean canAddApplications();
 
 	/**
-	 * Returns the name of this application provider.
+	 * Returns the name of this resource provider.
 	 * 
-	 * @return the name of this application provider.
+	 * @return the name of this resource provider.
 	 */
 	public String getName();
 
@@ -30,6 +30,15 @@ public interface ResourceProvider extends Serializable {
 	 * Initializes this provider. Convenience method to provide a lazy initialization.
 	 */
 	public void init();
+
+	/**
+	 * It is possible that some implementations will have problems during initialization due to, for instance, expired
+	 * certificates, unavailable resources, etc. This method will tell users of {@link ResourceProvider} that this
+	 * instance could not be properly initialized.
+	 * 
+	 * @return {@code true} if this provider had errors during initialization.
+	 */
+	public boolean hasInitErrors();
 
 	/**
 	 * Returns all computing resources for the user.
@@ -50,5 +59,5 @@ public interface ResourceProvider extends Serializable {
 	/**
 	 * Signals implementations that changes done to the resources should be saved.
 	 */
-	public void saveApplications();
+	public void save();
 }

--- a/core-lib/src/main/java/com/workflowconversion/portlet/core/resource/impl/InMemoryMockResourceProvider.java
+++ b/core-lib/src/main/java/com/workflowconversion/portlet/core/resource/impl/InMemoryMockResourceProvider.java
@@ -52,6 +52,7 @@ public class InMemoryMockResourceProvider implements ResourceProvider {
 
 	private void fillInitialResources() {
 		final Middleware[] middlewares = middlewareProvider.getAllMiddlewares().toArray(new Middleware[] {});
+
 		for (int i = 0; i < N_INITIAL_RESOURCES; i++) {
 			final Resource.Builder resourceBuilder = new Resource.Builder();
 			resourceBuilder.withType(getRandomResourceType(middlewares));
@@ -113,8 +114,14 @@ public class InMemoryMockResourceProvider implements ResourceProvider {
 	}
 
 	@Override
-	public void saveApplications() {
+	public void save() {
 		LOG.info("COMMITTING CHANGES");
 		// does nothing, since we're actually not storing anything
+	}
+
+	@Override
+	public boolean hasInitErrors() {
+		// TODO Auto-generated method stub
+		return false;
 	}
 }

--- a/core-lib/src/main/java/com/workflowconversion/portlet/core/workflow/impl/MockWorkflowManagerFactory.java
+++ b/core-lib/src/main/java/com/workflowconversion/portlet/core/workflow/impl/MockWorkflowManagerFactory.java
@@ -33,14 +33,14 @@ public class MockWorkflowManagerFactory implements WorkflowManagerFactory {
 
 	@Override
 	public WorkflowManager newInstance() {
-		return new MockWorkflowProvider();
+		return new MockWorkflowManager();
 	}
 
-	private static class MockWorkflowProvider implements WorkflowManager {
+	private static class MockWorkflowManager implements WorkflowManager {
 		final Map<String, Workflow> workflows;
 		private static int CURRENT_WF_ID = 0;
 
-		private MockWorkflowProvider() {
+		private MockWorkflowManager() {
 			workflows = new TreeMap<String, Workflow>();
 			// create some workflows
 			for (int i = 0; i < 5; i++) {

--- a/ui-components/src/main/java/com/workflowconversion/portlet/ui/WorkflowConversionUI.java
+++ b/ui-components/src/main/java/com/workflowconversion/portlet/ui/WorkflowConversionUI.java
@@ -91,7 +91,7 @@ public abstract class WorkflowConversionUI extends UI {
 
 	private void initApplicationProviders() {
 		// init any provider that needs initialization
-		LOG.info("initializing ApplicationProviders");
+		LOG.info("initializing resource providers");
 		for (final ResourceProvider provider : resourceProviders) {
 			if (LOG.isInfoEnabled()) {
 				LOG.info("initializing " + provider.getClass());

--- a/ui-components/src/main/java/com/workflowconversion/portlet/ui/resource/upload/BulkUploadApplicationsDialog.java
+++ b/ui-components/src/main/java/com/workflowconversion/portlet/ui/resource/upload/BulkUploadApplicationsDialog.java
@@ -265,7 +265,7 @@ public class BulkUploadApplicationsDialog extends Window {
 					formattedWarnings.append("</ul>");
 					NotificationUtils.displayWarning(formattedWarnings.toString());
 				}
-				resourceProvider.saveApplications();
+				resourceProvider.save();
 			} finally {
 				upload.setEnabled(true);
 			}

--- a/ui-components/src/main/java/com/workflowconversion/portlet/ui/table/AbstractTableWithControls.java
+++ b/ui-components/src/main/java/com/workflowconversion/portlet/ui/table/AbstractTableWithControls.java
@@ -81,17 +81,24 @@ public abstract class AbstractTableWithControls<T> extends VerticalLayout implem
 		this.detailsButton = createButton("Show details for selected item", FontAwesome.EYE);
 		this.containerProperties = new LinkedList<ContainerProperty>();
 		this.table = new Table();
+		init();
 	}
 
-	@Override
-	public void init(final Collection<T> initialElements) {
+	private void init() {
 		setUpContainerProperties();
 		setUpEditComponents();
 		setUpLayout();
 		setUpProperties();
 		setUpTable();
-		setInitialItems(initialElements);
 		setReadOnly(!allowEdition);
+	}
+
+	@Override
+	public final void setInitialItems(final Collection<T> initialItems) {
+		Validate.notNull(initialItems, "initialItems cannot be null.");
+		for (final T element : initialItems) {
+			insertItem_internal(element);
+		}
 	}
 
 	private void setUpEditComponents() {
@@ -344,13 +351,6 @@ public abstract class AbstractTableWithControls<T> extends VerticalLayout implem
 	private void validateEditionAllowed() {
 		if (!allowEdition) {
 			throw new TableIsReadOnlyException("This table does not allow editions.");
-		}
-	}
-
-	private void setInitialItems(final Collection<T> initialItems) {
-		Validate.notNull(initialItems, "initialItems cannot be null.");
-		for (final T element : initialItems) {
-			insertItem_internal(element);
 		}
 	}
 

--- a/ui-components/src/main/java/com/workflowconversion/portlet/ui/table/TableWithControls.java
+++ b/ui-components/src/main/java/com/workflowconversion/portlet/ui/table/TableWithControls.java
@@ -23,10 +23,10 @@ public interface TableWithControls<T>
 	/**
 	 * Initializes the table with the given elements.
 	 * 
-	 * @param initialElements
-	 *            a collection of the initial elements to display.
+	 * @param initialItems
+	 *            a collection of the initial items to display.
 	 */
-	void init(final Collection<T> initialElements);
+	void setInitialItems(final Collection<T> initialItems);
 
 	/**
 	 * Allow users to check this table's dimensions.

--- a/ui-components/src/main/java/com/workflowconversion/portlet/ui/table/resource/ResourceDetailsDialog.java
+++ b/ui-components/src/main/java/com/workflowconversion/portlet/ui/table/resource/ResourceDetailsDialog.java
@@ -16,8 +16,8 @@ import com.workflowconversion.portlet.ui.table.AbstractGenericElementDetailsDial
 import com.workflowconversion.portlet.ui.table.GenericElementDetailsSavedListener;
 import com.workflowconversion.portlet.ui.table.Size;
 import com.workflowconversion.portlet.ui.table.TableWithControls;
-import com.workflowconversion.portlet.ui.table.application.ApplicationsTable.ApplicationsTableFactory;
-import com.workflowconversion.portlet.ui.table.queue.QueuesTable.QueueTableFactory;
+import com.workflowconversion.portlet.ui.table.application.ApplicationTable.ApplicationTableFactory;
+import com.workflowconversion.portlet.ui.table.queue.QueueTable.QueueTableFactory;
 
 /**
  * Dialog to see/edit Applications and Queues of a resource.
@@ -63,16 +63,16 @@ public class ResourceDetailsDialog extends AbstractGenericElementDetailsDialog<R
 		saveButton.setEnabled(allowEdition);
 		saveButton.setDisableOnClick(true);
 
-		final ApplicationsTableFactory applicationsTableFactory = new ApplicationsTableFactory();
+		final ApplicationTableFactory applicationsTableFactory = new ApplicationTableFactory();
 		applicationsTableFactory.withOwningResource(super.element).allowEdition(super.element.canModifyApplications())
 				.withTitle("Applications");
 		final TableWithControls<Application> applicationsTable = applicationsTableFactory.newInstance();
-		applicationsTable.init(super.element.getApplications());
+		applicationsTable.setInitialItems(super.element.getApplications());
 
 		final QueueTableFactory queueTableFactory = new QueueTableFactory();
 		queueTableFactory.withTitle("Queues");
 		final TableWithControls<Queue> queueTable = queueTableFactory.newInstance();
-		queueTable.init(super.element.getQueues());
+		queueTable.setInitialItems(super.element.getQueues());
 
 		closeButton.addClickListener(new Button.ClickListener() {
 			private static final long serialVersionUID = 9168543231461290544L;


### PR DESCRIPTION
…lItems' method. Initialization of tables happens now at the constructor. Resource providers now have a mechanism for users to check if there were errors during intialization. If a resource provider had initialization errors, an error message will be displayed every time it is selected.